### PR TITLE
Update AsyncHttpClient.py

### DIFF
--- a/app/http_client/AsyncHttpClient.py
+++ b/app/http_client/AsyncHttpClient.py
@@ -187,6 +187,7 @@ class AsyncHttpClient:
         """
         async with self.semaphore:
             try:
+                self.aclient.headers["Referer"] = url
                 async with self.aclient.stream("GET", url) as response:
                     response.raise_for_status()
                     with open(save_path, "wb") as file:

--- a/app/model_pool/AsyncModelPool.py
+++ b/app/model_pool/AsyncModelPool.py
@@ -143,8 +143,8 @@ class AsyncModelPool:
         self.fast_whisper_download_root = faster_whisper_download_root
 
         self.min_size = min_size
-        self.max_size = self.get_optimal_max_size(max_size)
         self.max_instances_per_gpu = max_instances_per_gpu
+        self.max_size = self.get_optimal_max_size(max_size)
         self.init_with_max_pool_size = init_with_max_pool_size
         self.pool = Queue(maxsize=self.max_size)
         self.current_size = 0


### PR DESCRIPTION
This is to circumvent a restriction douyin put on its origin video url, headers without proper 'Referer' value will reveive 403 forbidden, thus failing to download the video